### PR TITLE
Fixed a jackson exception

### DIFF
--- a/src/main/java/de/ddb/pdc/core/Answer.java
+++ b/src/main/java/de/ddb/pdc/core/Answer.java
@@ -39,24 +39,6 @@ public enum Answer {
   UNKNOWN;
 
   /**
-   * Converts the answer to an integer used for the json serialization.
-   * NO = 0, YES = 1, ASSUMED_NO = 2, ASSUMED_YES = 3, UNKNOWN = 4
-   *
-   * @return 0 if the answer is no, 1 if the answer is yes, 2 if the answer
-   *         is assumed no, 3 if the answer is assumed yes, and 4 if the answer
-   *         is unknown
-   */
-  @JsonValue
-  public int toInteger() {
-    for (int index = 0; index < Answer.values().length; index++) {
-      if (Answer.values()[index] == this) {
-        return index;
-      }
-    }
-    return -1; // this should never happen
-  }
-
-  /**
    * Converts the answer into a string for the json serialization.
    * NO = "no", YES = "yes", ASSUMED_NO = "assumed no",
    * ASSUMED_YES = "assumed yes", UNKNOWN = "unknown"


### PR DESCRIPTION
As i found out, multiple methods annotated with @JsonValue will result in an Exception because Jackson does not know which one to use:

```
com.fasterxml.jackson.databind.JsonMappingException: 
Problem with definition of [AnnotedClass de.ddb.pdc.core.Answer]: 
Multiple value properties defined 
([method de.ddb.pdc.core.Answer#toInteger(0 params)] vs [method de.ddb.pdc.core.Answer#toString(0 params)]) 
(through reference chain: de.ddb.pdc.core.PDCResult)
```

Therefore i have removed the toInteger method. Please review and merge.
