### PR TITLE
Add missing JavaDoc comments

### DIFF
--- a/src/main/java/de/ddb/pdc/Main.java
+++ b/src/main/java/de/ddb/pdc/Main.java
@@ -22,16 +22,29 @@ public class Main {
   @Value("${ddb.apikey}")
   private String ddbApiKey;
 
+  /**
+   * The Spring RestTemplate instance which is used for communicating
+   * with the DDB API. It is injected as a bean to make it mockable
+   * in integration tests.
+   */
   @Bean
   public RestTemplate restTemplate() {
     return new RestTemplate();
   }
 
+  /**
+   * The singleton {@link MetaFetcher} instance.
+   */
   @Bean
   public MetaFetcher metaFetcher(RestTemplate restTemplate) {
     return new MetaFetcherImpl(restTemplate, ddbApiKey);
   }
 
+  /**
+   * The main method.
+   *
+   * @param args command-line arguments (interpreted by Spring Boot)
+   */
   public static void main(String[] args) throws Exception {
     SpringApplication.run(Main.class, args);
   }

--- a/src/main/java/de/ddb/pdc/crawler/Crawler.java
+++ b/src/main/java/de/ddb/pdc/crawler/Crawler.java
@@ -25,11 +25,17 @@ public class Crawler implements CommandLineRunner {
   private final int timeout = 1000;
   private final CrawlerSchedule schedule;
 
+  /**
+   * Creates a new Crawler.
+   */
   @Autowired
   public Crawler(CrawlerSchedule schedule) {
     this.schedule = schedule;
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void run(String... args) throws Exception {
     List<String> argsList = Arrays.asList(args);

--- a/src/main/java/de/ddb/pdc/crawler/CrawlerSchedule.java
+++ b/src/main/java/de/ddb/pdc/crawler/CrawlerSchedule.java
@@ -35,6 +35,9 @@ public class CrawlerSchedule extends Thread {
   private final MetaFetcher metaFetcher;
   private final PublicDomainCalculator calculator;
 
+  /**
+   * Creates a new CrawlerSchedule.
+   */
   @Autowired
   public CrawlerSchedule(MetaFetcher metaFetcher,
       PublicDomainCalculator calculator) {
@@ -71,6 +74,9 @@ public class CrawlerSchedule extends Thread {
     this.timeout = timeout;
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void run() {
     while (!end) {

--- a/src/main/java/de/ddb/pdc/metadata/DDBItem.java
+++ b/src/main/java/de/ddb/pdc/metadata/DDBItem.java
@@ -38,6 +38,9 @@ public class DDBItem {
     return id;
   }
 
+  /**
+   * Sets the item's ID.
+   */
   public void setId(String id) {
     this.id = id;
   }
@@ -49,6 +52,9 @@ public class DDBItem {
     return title;
   }
 
+  /**
+   * Sets the item's title.
+   */
   public void setTitle(String title) {
     this.title = title;
   }
@@ -61,6 +67,9 @@ public class DDBItem {
     return subtitle;
   }
 
+  /**
+   * Sets the item's subtitle.
+   */
   public void setSubtitle(String subtitle) {
     this.subtitle = subtitle;
   }
@@ -73,6 +82,9 @@ public class DDBItem {
     return imageUrl;
   }
 
+  /**
+   * Sets the item's thumbnail image URL.
+   */
   public void setImageUrl(String imageUrl) {
     this.imageUrl = imageUrl;
   }
@@ -85,6 +97,9 @@ public class DDBItem {
     return media;
   }
 
+  /**
+   * Sets the item's media type.
+   */
   public void setMedia(String media) {
     this.media = media;
   }
@@ -97,6 +112,9 @@ public class DDBItem {
     return category;
   }
 
+  /**
+   * Sets the item's category.
+   */
   public void setCategory(String category) {
     this.category = category;
   }
@@ -109,6 +127,9 @@ public class DDBItem {
     return type;
   }
 
+  /**
+   * Sets the item's type.
+   */
   public void setType(String type) {
     this.type = type;
   }
@@ -121,6 +142,9 @@ public class DDBItem {
     return authors;
   }
 
+  /**
+   * Adds an author to the list returned by {@link #getAuthors()}.
+   */
   public void addAuthor(Author author) {
     this.authors.add(author);
   }
@@ -133,6 +157,9 @@ public class DDBItem {
     return institution;
   }
 
+  /**
+   * Sets the item's institution.
+   */
   public void setInstitution(String institution) {
     this.institution = institution;
   }
@@ -145,6 +172,9 @@ public class DDBItem {
     return publishedYear;
   }
 
+  /**
+   * Sets the item's publishing year.
+   */
   public void setPublishedYear(int publishedYear) {
     if (publishedYear != -1) {
       this.publishedYear = new GregorianCalendar();

--- a/src/main/java/de/ddb/pdc/storage/MongoStorageService.java
+++ b/src/main/java/de/ddb/pdc/storage/MongoStorageService.java
@@ -25,6 +25,13 @@ public class MongoStorageService implements StorageService {
   private final MongoTemplate mongoTemplate;
   private final String collectionName;
 
+  /**
+   * Creates a new MongoStorageService.
+   *
+   * @param mongoTemplate  MongoTemplate to use
+   * @param collectionName name of the MongoDB collection to store
+   *                       results into
+   */
   @Autowired
   public MongoStorageService(MongoTemplate mongoTemplate,
           @Value("${collection.name:pdcData}") String collectionName) {


### PR DESCRIPTION
Most of these comments are trivial, but they help to remove clutter from the Checkstyle output, which will make spotting important warnings easier.

There are still a bunch of missing-JavaDoc warnings from `StorageModel`, but making that class package-private would remove them (see issue #47).
